### PR TITLE
Restore dark background and update accent color

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,9 +23,9 @@
 
   <style>
     :root{
-      --bg:#0b0c0c; --text:#e7e7e7; --muted:#a0a0a0;
+      --bg:#000000; --text:#e7e7e7; --muted:#a0a0a0;
       --card:#141515; --line:#1f2020;
-      --accent:#39ff14; /* neon moss */
+      --accent:#ff3fd7; /* bright pink */
       --radius:18px; --pad:18px; --gap:18px; --max:1080px;
       color-scheme: dark light;
     }
@@ -90,7 +90,7 @@
     .grid{display:grid; gap:var(--gap); grid-template-columns:repeat(auto-fit,minmax(260px,1fr)); margin-top:1rem;}
     .card{position:relative; background:var(--card); border:1px solid var(--line); border-radius:var(--radius); overflow:hidden; transition:transform .2s ease, box-shadow .2s ease, border-color .2s ease;}
     .card:hover{transform:translateY(-4px); border-color:color-mix(in oklab,var(--accent) 50%,var(--line)); box-shadow:0 10px 30px rgba(0,0,0,.2);}
-    .card img{display:block; width:100%; height:220px; object-fit:cover; filter:saturate(1.02);}
+    .card img{display:block; width:100%; height:220px; object-fit:cover;}
     .card__overlay{
       position:absolute; left:0; right:0; bottom:0;
       padding:12px 14px; color:#fff;


### PR DESCRIPTION
## Summary
- reset the dark theme background token to pure black
- switch the default accent color from lime green to bright pink
- remove image saturation filter to leave project thumbnails untouched

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68f5ebf10114832abbd9bb313ba956e8