### PR TITLE
Restore lime accent to default theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,15 +23,13 @@
 
   <style>
     :root{
-      --bg:#000000; --text:#e7e7e7; --muted:#a0a0a0;
+      --bg:#0b0c0c; --text:#e7e7e7; --muted:#a0a0a0;
       --card:#141515; --line:#1f2020;
-      --accent:#ff3fd7; /* bright pink */
+      --accent:#39ff14; /* neon moss */
       --radius:18px; --pad:18px; --gap:18px; --max:1080px;
       color-scheme: dark light;
     }
-    html.punk{
-      --accent:#ff3fd7; /* electric pink */
-    }
+    html.punk{ --accent:#ff3fd7; /* electric pink */ }
     @media (prefers-color-scheme: light){
       :root{ --bg:#ffffff; --text:#111; --muted:#565656; --card:#f8f8f8; --line:#eaeaea; }
     }


### PR DESCRIPTION
## Summary
- restore the default theme to use the neon green accent on the dark background
- keep punk mode active with the pink accent override for its glitch styling

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68f5ef838018832aa567047b5c0e69dd